### PR TITLE
Skip orphan assays in full ISA-Tab reader

### DIFF
--- a/ISA/lib/perl/Study.pm
+++ b/ISA/lib/perl/Study.pm
@@ -129,6 +129,15 @@ sub addNode {
 }
 sub getNodes { $_[0]->{_nodes} or [] }
 
+sub hasNode {
+  my ($self, $node) = @_;
+
+  foreach(@{$self->getNodes()}) {
+    return 1 if($node->equals($_));
+  }
+  return 0;
+}
+
 sub addEdge { 
   my ($self, $input, $protocolApplications, $output) = @_;
 


### PR DESCRIPTION
The first column in an assay file (`a_*.txt`) is `Sample Name` and links the assay to a sample that comes from the `s_samples.txt` "Study file" (identified also by `Sample Name`).

This PR will silently skip any row in an assay file if the sample does not already exist.

Some options to consider
1. make it a configurable option
2. emit a warning (in verbose mode?) when an assay is skipped